### PR TITLE
Add Additional Sponsors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ Temporary Items
 
 ### Jekyll ###
 _site/
+.bundle/
+vendor/
 .sass-cache/
 .jekyll-cache/
 .jekyll-metadata

--- a/_includes/sponsors.html
+++ b/_includes/sponsors.html
@@ -1,0 +1,87 @@
+<head>
+    <style>
+        @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap");
+
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #2e2e2e !important;
+                color: #e4e4e4 !important;
+            }
+
+            a {
+                color: #e4e4e4 !important;
+            }
+        }
+
+        ul.sponsors {
+            list-style-type: none;
+            overflow: hidden;
+            border: 1px solid rgb(255, 255, 255);
+            border-width: 3px;
+            list-style: none;
+            margin: 0;
+            padding: 0;
+            text-align: center;
+        }
+
+        ul li {
+            display: inline;
+            display: inline-block;
+            padding: 10px;
+        }
+
+        a {
+            color: black;
+            text-decoration: none;
+        }
+
+        a img {
+            border-radius: 50px;
+        }
+
+        .sponsors li {
+            margin: 20px
+        }
+
+        .sponsors li img {
+            margin-top: 1.05rem;
+        }
+    </style>
+</head>
+
+<body>
+    <main>
+        <center>
+            <ul id="sponsor-list" class="sponsors" style="margin-bottom: 50px;">
+            </ul>
+        </center>
+    </main>
+    <script>
+        const sponsorsData = document.getElementById("sponsor-list");
+
+        const user = "BlockchainCommons";
+        index = 0;
+
+        function getSponsorList() {
+            const xhr = new XMLHttpRequest();
+
+            function reqListener() {
+                sponsorsCount = JSON.parse(this.responseText).sponsors;
+                for (const t of sponsorsCount) {
+                    sponsorsData.innerHTML += `
+       <li class="sponsor"> <a href="${t.profile}">
+       ${t.handle}
+         <br>
+           <img src="https://trnck.dev/proxy?url=${t.avatar}" width="60">
+       </a>
+       </li>
+       `;
+                }
+            }
+            xhr.addEventListener("load", reqListener);
+            xhr.open("GET", `https://sponsors.trnck.dev/sponsors/${user}`);
+            xhr.send();
+        }
+        getSponsorList();
+    </script>
+</body>

--- a/sponsors.md
+++ b/sponsors.md
@@ -32,9 +32,9 @@ Sustaining patrons have made an ongoing commitment of funds for the support of B
 
 ## Additional Sponsors
 
-Thanks also to our ongoing [Github Sponsors](https://github.com/sponsors/BlockchainCommons): Adrian Gropper ([@agropper](https://github.com/agropper)), Mark S. Miller ([@erights](https://github.com/erights)), Glenn Willen ([@gwillen](https://github.com/gwillen)), Alexandre Linhares ([@Alex-Linhares](https://github.com/Alex-Linhares)), Trent McConaghy ([@trentmc](https://github.com/trentmc)), Eric Kuhn ([@erickuhn19](https://github.com/erickuhn19)), Zach Herbert ([@zachherbert](https://github.com/zachherbert)), Dario ([@mytwocentimes](https://github.com/mytwocentimes)), [@modl21](https://github.com/modl21), Protocol Labs ([@protocol](https://github.com/protocol)), and four additional sponsors.
-
+{% include sponsors.html %}
 
 ## Become a Sponsor!
 
 Please support Blockchain Commons by becoming a [sustaining sponsor](https://github.com/sponsors/BlockchainCommons) or making a [BTCPay donation](https://btcpay.blockchaincommons.com/).
+


### PR DESCRIPTION
## Description

Add additional sponsors to the Website. 

This PR: 

- [X] Fetch the sponsor data from [sponsors.trnck.dev](https://sponsors.trnck.dev/)
- [X] Uses XML HttpRequest object to fetch data from the API above 
- [X] Parses the JSON Data and display it on the HTML Page
- [X] Injects the HTML Page to the Jekyll Markdown 

Addresses the issue here: https://github.com/BlockchainCommons/Community/issues/24

## Demo

![Tab-1624473106488](https://user-images.githubusercontent.com/47351025/123150131-a3dc7000-d47f-11eb-8175-5999dbabdf1e.gif)

## Tests 

Tested on: 

- Windows-10 
- Google Chrome (Version 91.0.4472.77)


